### PR TITLE
add support to official volley lib

### DIFF
--- a/{{ cookiecutter.dir_name }}/AndroidManifest.xml
+++ b/{{ cookiecutter.dir_name }}/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/{{ cookiecutter.dir_name }}/build.gradle
+++ b/{{ cookiecutter.dir_name }}/build.gradle
@@ -60,6 +60,10 @@ project.afterEvaluate {
 }
 
 dependencies {
+    repositories {
+        jcenter()
+    }
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.volley:volley:1.1.0'
 }

--- a/{{ cookiecutter.dir_name }}/src/android/PythonVolleyJsonRequest.java
+++ b/{{ cookiecutter.dir_name }}/src/android/PythonVolleyJsonRequest.java
@@ -1,0 +1,29 @@
+package android;
+
+import com.android.volley.Response;
+import com.android.volley.Response.ErrorListener;
+import com.android.volley.Response.Listener;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+
+public class PythonVolleyJsonRequest extends com.android.volley.toolbox.JsonObjectRequest {
+	private HashMap<String, String> mHeaders;
+
+	public PythonVolleyJsonRequest(int method, String url, JSONObject jsonRequest, Listener<JSONObject> listener,
+            ErrorListener errorListener, HashMap<String, String> headers) {
+	        super(method, url, jsonRequest, listener,
+				errorListener);
+		mHeaders = headers;
+	}
+
+	public void setHeaders(HashMap<String, String> headers) {
+		mHeaders = headers;
+	}
+
+	public HashMap<String, String> getHeaders() {
+		return mHeaders;
+	}
+}


### PR DESCRIPTION
You'll can make a json request with headers, without need to modify the volley lib, like that:
```
jsonRequest = android.PythonVolleyJsonRequest(
            1,
            url,
            testJson,
            OnResponse(self.listener),
            OnError(self.listener_error),
            HashMap()
            )
self.queue.add(jsonRequest)
```
The number 1 represents the post method.